### PR TITLE
WIP: Podcast RSS proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem 'selenium-webdriver'
 
   gem 'rspec-rails', '~> 3.7'
+  gem 'rails-controller-testing'
 
   gem 'coveralls', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.6)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -370,6 +374,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rack-timeout
   rails (~> 5.1.6)
+  rails-controller-testing
   react_on_rails (= 10.1.3)
   rspec-rails (~> 3.7)
   sass-rails (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Click "Ad a new job", enter `rake invoices:process` and press `Save`. Set freque
 
 It's free to use your own domain with Heroku. SSL for your own domain is also easy to setup, but not free.
 
+## Podcast RSS feed
+
+In order to provide a podcast feed for your supporters, you need to configure
+some channel metadata and provide a URL of an existing podcast RSS feed. Uploading 
+episodes directly isn't supported yet, see #25.
+
+```sh
+heroku config:add PODCAST=1
+heroku config:add PODCAST_TITLE='Sjorsnado Podcast'
+heroku config:add PODCAST_IMAGE=https://example.com/podcast.png
+heroku config:add PODCAST_URL=https://example.com/podcast.rss
+```
+
+In Heroku click "Ad a new job", enter `rake podcast:fetch` and press `Save`. Suggested frequency is hourly.
+
 ## Development
 
 Install [RVM](https://rvm.io) (Ruby Version Manager) and `rvm install` the right [Ruby version](Gemfile#L1). Install [NVM](https://github.com/creationix/nvm#install-script) (Node Version Manager) and `nvm install` the right NodeJS version, see `{engines: {node: ...}}` in [package.json](package.json).

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,8 @@ class HomeController < ApplicationController
     @layout_props = { 
       isLoggedIn: current_user.present?,
       isContributor: current_user && current_user.contribution.amount > 0,
-      contributorCount: Contribution.active_count   
+      contributorCount: Contribution.active_count,
+      podcastUrl: current_user.present? ? podcast_url(token: current_user.podcast_token, format: :rss) : nil
     }
   end
 end

--- a/app/controllers/podcast_controller.rb
+++ b/app/controllers/podcast_controller.rb
@@ -1,0 +1,14 @@
+class PodcastController < ApplicationController
+  # Future CRUD should use /podcast/episodes 
+  
+  # GET /podcast.rss
+  def feed
+    @user = User.find_by_podcast_token(params[:token])
+    if @user
+      @episodes = Podcast.published.where("pub_date < ?", @user.contribution.subscribed_up_to)
+    else
+      @episodes = [] # Later: list public episodes
+    end
+    @last_pubdate = @episodes.count > 0 ? @episodes.first.pub_date : Time.zone.local(2018, 05, 01)
+  end
+end

--- a/app/javascript/bundles/Matreon/components/Contribution/Contribution.jsx
+++ b/app/javascript/bundles/Matreon/components/Contribution/Contribution.jsx
@@ -39,6 +39,10 @@ class Contribution extends React.Component {
     if (!window.layoutProps.isLoggedIn) {
       window.location='/users/sign_in';
     }
+    
+    this.state = {
+      podcastUrl: window.layoutProps.podcastUrl 
+    }
   }
 
   updateAmount(e) {
@@ -90,6 +94,17 @@ class Contribution extends React.Component {
           </Col>
         </FormGroup>
         </Form>
+        { this.state.podcastUrl &&
+          <div>
+          <h3>Podcast</h3>
+          <p>
+            Private podcast URL: <a href={ this.state.podcastUrl }>{ this.state.podcastUrl }</a>
+          </p>
+          <p>
+            Once you've paid each month's invoice, new episodes will appear until the next month. If you stop paying, previous episodes will remain available.   
+          </p>
+          </div>
+        }
       </div>
     );
   }

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -10,6 +10,19 @@ class Contribution < ApplicationRecord
   def as_json(options = nil)
     super({ only: [:amount] }.merge(options || {}))
   end
+  
+  def subscribed_up_to
+    # If user never paid an invoice, return a date far in the past:
+    if user.invoices.count == 0 || (user.invoices.count == 1 && user.invoices.first.status != "paid")
+      return Time.zone.local(2000, 01, 01) 
+    # If most recent invoice is paid, return 1 month past the invoice date:
+    elsif user.invoices.first.status == "paid"
+      return user.invoices.first.created_at + 1.month
+    # Return 1 month past the previous invoice date::
+    else
+      return user.invoices.second.created_at + 1.month
+    end
+  end
 
   def self.active_count
     # TODO: exclude contributors more than 1 month behind in payments

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -93,7 +93,7 @@ class Invoice < ApplicationRecord
     invoice = {
       msatoshi: amount * 1000,
       description: "Matreon",
-      expiry: 60 * 60 * 24 * 7 # 1 week
+      expiry: 60 * 60 * 24 * 7 # 1 week, TODO: add invoices.expires_at
     }
   
     request = http_request("POST", uri)

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -1,0 +1,35 @@
+require 'rss'
+require 'open-uri'
+
+class PodcastError < StandardError; end
+
+class Podcast < ApplicationRecord
+  default_scope { order(pub_date: :desc) }
+  
+  scope :published, -> { where('pub_date <= ?', Time.now.utc) }
+
+  def self.fetch!
+    raise PodcastError.new("Podcast feature disabled") unless ENV['PODCAST'] == "1"
+    ActiveRecord::Base.transaction do
+      # Track episode guids to delete stale ones:  
+      episode_guids = []
+
+      RSS::Parser.parse(open(ENV['PODCAST_URL']).read, false).items.each do |episode|
+        if !episode.guid || !episode.guid.content 
+          raise PodcastError.new("Unable to parse podcast feed, missing guid for episode")
+        end
+        episode_guids << episode.guid.content
+        @podcast = Podcast.where(guid: episode.guid.content, external: true).first_or_create!
+        @podcast.update(
+          pub_date: episode.pubDate,
+          title: episode.title,
+          description: episode.description,
+          url: episode.link
+        )
+      end
+      
+      # Remove episodes that were deleted upstream:
+      Podcast.where(external: true).where("guid NOT IN (?)", episode_guids).destroy_all
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_secure_token :podcast_token
+  
   before_create :initialize_contribution
   before_destroy :remove_contribution
   

--- a/app/views/podcast/feed.rss.builder
+++ b/app/views/podcast/feed.rss.builder
@@ -1,0 +1,31 @@
+#encoding: UTF-8
+
+xml.instruct! :xml, :version => "1.0"
+
+xml.rss :version => "2.0", "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd" do
+  xml.channel do
+    xml.title ENV["PODCAST_TITLE"]
+    xml.link ENV["HOSTNAME"]
+    xml.language 'en'
+    xml.pubDate @last_pubdate.to_s(:rfc822)
+    xml.lastBuildDate @last_pubdate.to_s(:rfc822)
+    xml.itunes :author, ENV["PODCAST_TITLE"]
+    xml.itunes :image, :href => ENV["PODCAST_IMAGE"]
+    xml.itunes :owner do
+      xml.itunes :name, ENV["PODCAST_TITLE"]
+      xml.itunes :email, ENV["FROM_EMAIL"]
+    end
+    xml.itunes :block, 'no'
+
+    @episodes.each do  |episode|
+      xml.item do
+        xml.title episode.title
+        xml.description episode.description
+        xml.pubDate episode.pub_date.to_s(:rfc822)
+        xml.enclosure :url => episode.url, :length => 0, :type => 'audio/mpeg'
+        xml.link episode.url
+        xml.guid({:isPermaLink => episode.guid[0..3] == "http" ? "true" : "false"}, episode.guid)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,12 @@ Rails.application.routes.draw do
     resource :contribution
     resources :invoices
   end
+  
+  scope format: true, constraints: { format: /rss/ } do
+    scope '/podcast' do
+      get '/' => 'podcast#feed', as: :podcast
+    end 
+  end
 
   # Let react-router handle this:
   get 'contribution', to: 'home#index'

--- a/db/migrate/20180501140126_create_podcasts.rb
+++ b/db/migrate/20180501140126_create_podcasts.rb
@@ -1,0 +1,14 @@
+class CreatePodcasts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :podcasts do |t|
+      t.string :guid
+      t.datetime :pub_date
+      t.string :title
+      t.text :description
+      t.string :url
+      t.boolean :external
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180502093551_add_podcast_token_to_user.rb
+++ b/db/migrate/20180502093551_add_podcast_token_to_user.rb
@@ -1,0 +1,15 @@
+class AddPodcastTokenToUser < ActiveRecord::Migration[5.1]
+  def down
+    remove_index :users, :podcast_token
+    remove_column :users, :podcast_token
+  end
+  
+  def up
+    add_column :users, :podcast_token, :string
+    add_index :users, :podcast_token, unique: true
+
+    User.all.each do |user|
+      user.regenerate_podcast_token
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180421162802) do
+ActiveRecord::Schema.define(version: 20180502093551) do
 
   create_table "contributions", force: :cascade do |t|
     t.integer "user_id"
@@ -34,6 +34,17 @@ ActiveRecord::Schema.define(version: 20180421162802) do
     t.index ["user_id"], name: "index_invoices_on_user_id"
   end
 
+  create_table "podcasts", force: :cascade do |t|
+    t.string "guid"
+    t.datetime "pub_date"
+    t.string "title"
+    t.text "description"
+    t.string "url"
+    t.boolean "external"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -51,7 +62,9 @@ ActiveRecord::Schema.define(version: 20180421162802) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "podcast_token"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["podcast_token"], name: "index_users_on_podcast_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/lib/tasks/podcast.rake
+++ b/lib/tasks/podcast.rake
@@ -1,0 +1,6 @@
+namespace :podcast do :env
+  desc "Fetch podcast RSS"
+  task :fetch => :environment do
+    Podcast.fetch!
+  end
+end

--- a/spec/controllers/podcast_spec.rb
+++ b/spec/controllers/podcast_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PodcastController, type: :controller do
+  fixtures :users, :contributions, :invoices, :podcasts
+
+  describe "GET feed" do
+    it "should not have private @episodes without authentication" do
+      get :feed, format: :rss
+      expect(assigns(:episodes)).to eq([])
+    end
+    
+    it "should have @episodes with token" do
+      get :feed, format: :rss, params: {token: users(:dave).podcast_token}
+      expect(assigns(:episodes)).to eq([podcasts(:ep1)])
+    end
+
+    describe "RSS feed" do
+      render_views
+      
+      it "should be rendered" do
+        get :feed, format: :rss
+        expect(response).to render_template("feed")
+        expect(response.body).to include("Sjorsnado")
+      end
+      
+      it "should contain episodes" do
+        get :feed, format: :rss, params: {token: users(:dave).podcast_token}
+        expect(response).to render_template("feed")
+        expect(response.body).to include('<link>https://example.com/podcast/1.mp3')
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/podcast.rss
+++ b/spec/fixtures/files/podcast.rss
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Sjorsnado Podcast</title>
+    <item>
+      <title>Episode 2</title>
+      <link>https://example.com/podcast/2.mp3</link>
+      <description>Another long rant</description>
+      <guid>2</guid>
+      <pubDate>Sun, 29 Apr 2018 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Episode 1</title>
+      <link>https://example.com/podcast/1.mp3</link>
+      <description>Long rant</description>
+      <guid>1</guid>
+      <pubDate>Sun, 22 Apr 2018 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/spec/fixtures/podcasts.yml
+++ b/spec/fixtures/podcasts.yml
@@ -1,0 +1,7 @@
+ep1:
+  guid: "1"
+  title: "Episode 1"
+  description: "Long rant"
+  url: "https://example.com/podcast/1.mp3"
+  pub_date: "2018-01-01"
+  external: true

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -2,12 +2,16 @@
 
 alice:
   email: "alice@matreon.zz"
+  podcast_token: "token_alice"
 
 bob:
   email: "bob@matreon.zz"
+  podcast_token: "token_bob"
 
 carol:
   email: "carol@matreon.zz"
+  podcast_token: "token_carol"
 
 dave:
   email: "dave@matreon.zz"
+  podcast_token: "token_dave"

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -19,6 +19,25 @@ RSpec.describe Contribution, :type => :model do
       expect(users(:alice).contribution.billing_day_of_month).to eq(28)
     end
   end
+  
+  describe "subscribed_up_to" do
+    it "should return something long ago for users without invoices" do
+      users(:alice).create_contribution(amount: 0)
+      expect(users(:alice).contribution.subscribed_up_to).to eq(Time.zone.local(2000, 01, 01) )
+    end
+    
+    it "should return something long ago for users with no paid invoices" do
+      users(:alice).create_contribution(amount: 1)
+      expect(users(:alice).contribution.subscribed_up_to).to eq(Time.zone.local(2000, 01, 01) )
+    end
+    
+    it "should return 1 month after the last paid invoice" do
+      users(:alice).create_contribution(amount: 1)
+      users(:alice).invoices.first.update status: "paid"
+
+      expect(users(:alice).contribution.subscribed_up_to).to eq(Time.zone.local(2018, 03, 01) )
+    end
+  end
 
   describe "self.active_count" do
     it "should exlude 0 satoshi contributors" do

--- a/spec/models/podcast_spec.rb
+++ b/spec/models/podcast_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Podcast, type: :model do
+  describe "self.fetch!" do
+    before do
+      rss_fixture = File.read(File.new(Rails.root.join("spec/fixtures/files/podcast.rss")))
+      allow_any_instance_of(Kernel).to receive(:open).and_return(OpenStruct.new(read: rss_fixture))                 
+    end
+  
+    it "should throw if PODCAST=0" do
+      cached_env_podcast = ENV['PODCAST']
+      ENV['PODCAST'] = "0"
+      expect{Podcast.fetch!}.to raise_error(PodcastError)
+      ENV['PODCAST'] = cached_env_podcast
+    end
+  
+    it "should download and parse an RSS feed" do
+      Podcast.fetch!
+      expect(Podcast.count).to eq(2)
+    end
+    
+    it "should update entries if needed" do
+      Podcast.fetch!
+      Podcast.find_by(guid: "1").update(description: "Earlier version")
+      Podcast.fetch!
+      expect(Podcast.find_by(guid: "1").description).to eq("Long rant")
+    end
+    
+    it "should delete items no longer in the RSS feed" do
+      # Create "deleted" episode:
+      Podcast.create(guid: "deleted", title: "Oops", description: "I did it again", external: true)
+      
+      Podcast.fetch!
+      expect(Podcast.count).to eq(2)
+    end
+    
+    it "should not delete non-external items" do
+      # Create "deleted" episode:
+      Podcast.create(guid: "local", title: "Rant", description: "Blah", external: false)
+      
+      Podcast.fetch!
+      expect(Podcast.where(guid: "local").count).to eq(1)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,9 @@
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 ENV['FROM_EMAIL'] ||= 'test@matreon.zz'
+ENV['PODCAST'] ||= '1'
+ENV['PODCAST_URL'] ||= 'https://example.com/podcast.rss'
+ENV['PODCAST_TITLE'] ||= 'Sjorsnado Podcast'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/tasks/podcast_rake_spec.rb
+++ b/spec/tasks/podcast_rake_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe "podcast:fetch" do
+  include_context "rake"
+
+  it "should call :fetch! on Podcast" do
+    expect(Podcast).to receive(:fetch!)
+    subject.invoke
+  end
+end


### PR DESCRIPTION
Fetches an existing Podcast RSS feed and creates, stores the episodes
and produces a new private RSS feed.

Todo:
- [x] fetch RSS and store in database
- [x] update entries
- [x] RSS feed
- [x] unique private RSS URL for each user (does not require session)
- [x] do not show new RSS entries if user is late on payments (or if user has never paid)

Fixes #23