### PR TITLE
Use SSD disk instead of RAM disk, on storage optimized machine

### DIFF
--- a/Matreon.Template
+++ b/Matreon.Template
@@ -239,7 +239,7 @@ Resources:
             /tmp/wait_for_ibd.sh:
               content: !Sub |-
                 #!/bin/bash
-                export OPTS="-conf=/etc/bitcoin/bitcoin.conf -datadir=/mnt/ramdisk/bitcoin"
+                export OPTS="-conf=/etc/bitcoin/bitcoin.conf -datadir=/mnt/ssd/bitcoin"
                 while sleep 60
                 do
                   if bitcoin-cli $OPTS getblocktemplate; then
@@ -255,7 +255,7 @@ Resources:
                     break
                   fi
                 done
-                mv /mnt/ramdisk/bitcoin /home/bitcoin/.bitcoin
+                mv /mnt/ssd/bitcoin /home/bitcoin/.bitcoin
                 
               owner: bitcoin
               group: bitcoin
@@ -429,12 +429,15 @@ Resources:
               command: cd /usr/local/src/matreon && docker-compose build
         initial_blockchain_download:
           commands:
-            01_create_ram_disk:
-              command: mkdir /mnt/ramdisk && mount -t tmpfs -o size=55000m tmpfs
-                /mnt/ramdisk && mkdir /mnt/ramdisk/bitcoin && chown -R bitcoin:bitcoin /mnt/ramdisk/bitcoin
-            02_start_bitcoind:
-              command: su - bitcoin --command "bitcoind -conf=/etc/bitcoin/bitcoin.conf -datadir=/mnt/ramdisk/bitcoin -dbcache=4000 -prune=50000 -daemon"
-            03_wait_for_sync_prune_copy_stop:
+            01_format_ssd:
+              command: mkfs.ext4 -E nodiscard /dev/nvme0n1
+            02_mount_ssd:
+              command: mkdir /mnt/ssd && mount -o discard /dev/nvme0n1 /mnt/ssd
+            03_add_bitcoin_dir:
+              command: mkdir /mnt/ssd/bitcoin && chown -R bitcoin:bitcoin /mnt/ssd/bitcoin
+            04_start_bitcoind:
+              command: su - bitcoin --command "bitcoind -conf=/etc/bitcoin/bitcoin.conf -datadir=/mnt/ssd/bitcoin -dbcache=20000 -prune=1 -daemon"
+            05_wait_for_sync_prune_copy_stop:
               command: su - bitcoin --command "/tmp/wait_for_ibd.sh"
         prepare_matreon:
           commands:
@@ -462,7 +465,7 @@ Resources:
 
     Properties:
       ImageId: ami-43eec3a8
-      InstanceType: m5.4xlarge
+      InstanceType: i3.2xlarge
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:
@@ -481,7 +484,7 @@ Resources:
           /opt/aws/bin/cfn-signal -e $?          --stack ${AWS::StackId}         --resource WebServer          --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT600M
+        Timeout: PT360M
   IPAddress:
     Type: AWS::EC2::EIP
   IPAssoc:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is currently quite brittle and not very secure.
 
 Install the Amazon CloudFormation template by downloading [Matreon.Template](https://raw.githubusercontent.com/Sjors/matreon/master/Matreon.Template) and then uploading it on the [CloudFormation stack creation page](https://eu-central-1.console.aws.amazon.com/cloudformation/home?region=eu-central-1&stackName=Matreon#/stacks/new).
 
-Fill out the form, click next a few times and then wait while it installs applications and downloads the blockchain. After about half an hour on testnet or ten hours on mainnet the status should change from `CREATE_IN_PROGRESS` to `CREATE_COMPLETE`.
+Fill out the form, click next a few times and then wait while it installs applications and downloads the blockchain. After about half an hour on testnet or four hours on mainnet the status should change from `CREATE_IN_PROGRESS` to `CREATE_COMPLETE`.
 
 In order to download the blockchain in a reasonable amount of time, a high performance machine was used. Similar to how a sea squirt eats its own brain when it finds a place to stay and no longer needs to swim, you should downgrade to a cheaper machine once the blockchain has been downloaded.
 


### PR DESCRIPTION
Avoids the need to prune, which slows down IBD by a factor 3 or so.

The i3.2xlarge costs $0.744 per hour, vs. $0.96 for the m5.4xlarge.
In order to avoid pruning on a RAM drive you'd need the r4.8xlarge
which costs $2.561 / hour.