### PR TITLE
Make puma config work with any application root path

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -26,14 +26,14 @@ if ENV['HEROKU']
   port        ENV.fetch("PORT") { 3000 }
 else
   # Set up socket location
-  bind "unix:///var/www/matreon/tmp/puma.sock"
+  bind "unix://#{app_dir}/tmp/puma.sock"
 
   # Logging
   stdout_redirect "#{app_dir}/log/puma.stdout.log", "#{app_dir}/log/puma.stderr.log", true
 
   # Set master PID and state locations
-  pidfile "/var/www/matreon/tmp/puma.pid"
-  state_path "/var/www/matreon/tmp/puma.state"
+  pidfile "#{app_dir}/tmp/puma.pid"
+  state_path "#{app_dir}/tmp/puma.state"
   activate_control_app
 end
 


### PR DESCRIPTION
#### Description

Make puma config work with any application root path.

The puma config currently requires the application to be located in `/var/www/matreon/`.

#### Context

If the application is not in `/var/www/matreon/`, running puma fails with:

```
=== puma startup: 2018-07-16 03:27:24 +0800 ===
Errno::ENOENT: No such file or directory @ rb_sysopen - /var/www/matreon/tmp/puma.pid
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/lib/puma/launcher.rb:130:in `initialize'
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/lib/puma/launcher.rb:130:in `open'
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/lib/puma/launcher.rb:130:in `write_pid'
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/lib/puma/launcher.rb:103:in `write_state'
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/lib/puma/cluster.rb:445:in `run'
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/lib/puma/launcher.rb:183:in `run'
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/lib/puma/cli.rb:77:in `run'
  /home/klim/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.11.3/bin/puma:10:in `<top (required)>'
  /home/klim/.rbenv/versions/2.4.2/bin/puma:23:in `load'
  /home/klim/.rbenv/versions/2.4.2/bin/puma:23:in `<top (required)>'
```